### PR TITLE
Fix local solr deployment to also run in solr cloud mode

### DIFF
--- a/docker/docker-compose-all.yaml
+++ b/docker/docker-compose-all.yaml
@@ -112,7 +112,7 @@ services:
       SOLR_HEAP: 2g
       SOLR_MODE: solrcloud
     healthcheck:
-      test: [ "CMD-SHELL", "curl -sf http://localhost:8983/solr/bie/admin/ping | grep '\"status\":\"OK\"'" ]
+      test: [ "CMD-SHELL", "curl -sf http://localhost:8983/solr/" ]
     networks:
       default:
         aliases:

--- a/docker/docker-compose-all.yaml
+++ b/docker/docker-compose-all.yaml
@@ -106,9 +106,11 @@ services:
     ports:
       - "8983:8983"
     volumes:
-      - ./solr-data:/var/solr/data
+      - ./solr-data:/var/solr/init/docker/solr-data:ro
+      - solr-data:/var/solr/data
     environment:
       SOLR_HEAP: 2g
+      SOLR_MODE: solrcloud
     healthcheck:
       test: [ "CMD-SHELL", "curl -sf http://localhost:8983/solr/bie/admin/ping | grep '\"status\":\"OK\"'" ]
     networks:
@@ -206,3 +208,4 @@ volumes:
   mongo:
   postgis:
   elasticsearch:
+  solr-data:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -396,11 +396,13 @@ services:
     ports:
       - "8983:8983"
     volumes:
-      - ./solr-data:/var/solr/data
+      - ./solr-data:/var/solr/init/docker/solr-data:ro
+      - solr-data:/var/solr/data
     environment:
-      SOLR_HEAP: 4g
+      SOLR_HEAP: 2g
+      SOLR_MODE: solrcloud
     healthcheck:
-      test: [ "CMD-SHELL", "curl -sf http://localhost:8983/solr/bie/admin/ping | grep '\"status\":\"OK\"'" ]
+      test: [ "CMD-SHELL", "curl -sf http://localhost:8983/solr/" ]
     networks:
       default:
         aliases:


### PR DESCRIPTION
This should make the local development solr run in the same way as the solr running in AWS.
It does require manual creation of the solr config sets and collections whenever the solr-data volume is created.

Running the exact same commands as we do on terraform, should accomplish registering the config sets:
https://github.com/inbo/inbo-aws-biodiversiteitsportaal-terraform/blob/6cbba93db97e0b889f3fbe2a0b589842968fb8f1/region/common-region/solr-deployment/ecs.tf#L126
