### PR TITLE
#61: Fix serving static pages localy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ To make this work locally, you need to add the following lines to your `/etc/hos
 127.0.0.1 localhost branding.la-flanders.org collections.la-flanders.org records.la-flanders.org records-ws.la-flanders.org species-ws.la-flanders.org auth.la-flanders.org logger.la-flanders.org images.la-flanders.org lists.la-flanders.org regions.la-flanders.org species.la-flanders.org la-flanders.org spatial.la-flanders.org index.la-flanders.org mock-oauth2-server
 ```
 
+To generate the static pages like the homepage and styling, you also need to run the following command in the [branding folder](./branding)
+```commandline
+npm install
+npx brunch build --production
+```
+
 #### Differences with the cloud environments
 Because some AWS Cloud services are not available locally, alternatives are used in the local environment.
 These are:

--- a/docker/docker-compose-all.yaml
+++ b/docker/docker-compose-all.yaml
@@ -166,7 +166,7 @@ services:
     image: nginx
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d
-      - ../generated/la-flanders-branding/public:/srv/branding.la-flanders.org/www/
+      - ../branding/public:/srv/branding.la-flanders.org/www/
     ports:
       - "80:80"
     environment:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -455,7 +455,7 @@ services:
     image: nginx
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d
-      - ../generated/la-flanders-branding/public:/srv/branding.la-flanders.org/www/
+      - ../branding/public:/srv/branding.la-flanders.org/www/
     ports:
       - "80:80"
     environment:


### PR DESCRIPTION
Was broken after cleaning up the project structure and moving the static pages to the branding folder.