### PR TITLE
#107 - Use the primary color (purple) for dots on the map

### DIFF
--- a/config/bie-hub/bie-hub.yml
+++ b/config/bie-hub/bie-hub.yml
@@ -135,9 +135,10 @@ defaultZoomLevel: 9
 map:
   default:
     url: https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png
+    colour: a83d7a
   simpleMapButton: False
   records:
-    colour: e6704c
+    colour: a83d7a
 
 
 


### PR DESCRIPTION
Set the dots color on leaflet map to VBP primary color. Currently for bie-hub only