### PR TITLE
#83 - replace the default api_key with a dummy token

### DIFF
--- a/config/spatial-hub/spatial-hub.yml
+++ b/config/spatial-hub/spatial-hub.yml
@@ -182,6 +182,7 @@ google:
   apikey: "get-a-google-api-key"
 
 apiKeyCheckUrlTemplate: "${common.protocol}://${common.domain}/apikey/ws/check?apikey={0}"
+api_key: "dummy"
 autocompleteUrl: "${common.protocol}://${common.domain}/bie-index/search/auto.jsonp"
 
 auth:


### PR DESCRIPTION
  replace the default api_key with a dummy token with no whitespaces so it does not break the webservice' URI