### PR TITLE
#73: Fix sender e-mail for alerts service

### DIFF
--- a/config/alerts/alerts.yml
+++ b/config/alerts/alerts.yml
@@ -10,9 +10,9 @@ mail:
   ses:
     enabled: false
   details:
-    sender: "alerts@${common.domain}"
+    sender: "${common.supportEmail}"
     alertAddressTitle: "Atlas alerts"
-    infoSender: "alerts@${common.domain}"
+    infoSender: "${common.supportEmail}"
     infoAddressTitle: "Atlas of Living Australia"
     defaultResourceName: "Atlas of Living Australia"
     # forceAllAlertsGetSent results in emails getting sent regardless if data has changed - only use in DEV env


### PR DESCRIPTION
Only the support e-mail address is allowed as a sender on AWS.
As this requires the e-mail to be validated,