### PR TITLE
#97: Fix issue with Fish speciesGroup query not working correctly

### DIFF
--- a/config/biocache-service/pipelines-field-config.json
+++ b/config/biocache-service/pipelines-field-config.json
@@ -394,9 +394,6 @@
       "Terrestrial": "TERRESTRIAL",
       "Marine": "MARINE"
     },
-    "speciesGroup": {
-      "Fish": "Fishes"
-    },
     "month": {
       "January": "1",
       "February": "2",


### PR DESCRIPTION
Seems like this does some kind of mapping.
Probably used in Australia when migrating to the pipelines.