### PR TITLE
#102: do not only check out head when using explicit commit hashes 

### DIFF
--- a/docker/bie-hub/Dockerfile
+++ b/docker/bie-hub/Dockerfile
@@ -11,7 +11,7 @@ ARG COMMIT=15ad276721bb4c970c87933ff4edaf7128bc0e59
 ARG SOURCE=https://github.com/inbo/ala-bie-hub.git
 LABEL ala.version=inbo-${COMMIT}
 
-RUN git clone --branch ${VERSION} --depth 1 ${SOURCE} . && git checkout ${COMMIT}
+RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
 
 COPY ./i18n/ ./grails-app/i18n/
 

--- a/docker/biocache-hub/Dockerfile
+++ b/docker/biocache-hub/Dockerfile
@@ -7,7 +7,7 @@ ARG SOURCE=https://github.com/inbo/biocache-hubs.git
 LABEL ala.version=inbo-${COMMIT}
 
 WORKDIR /project/biocache-hubs
-RUN git clone --branch ${VERSION} --depth 1 ${SOURCE} . && git checkout ${COMMIT}
+RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
 
 RUN --mount=type=cache,target=/gradle-cache,ro \
     gradle build publishToMavenLocal \
@@ -19,7 +19,7 @@ ARG SOURCE=https://github.com/inbo/ala-hub.git
 LABEL ala.version=inbo-${COMMIT}
 
 WORKDIR /project/ala-hub
-RUN git clone --branch ${VERSION} --depth 1 ${SOURCE} . && git checkout ${COMMIT}
+RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
 
 # # TODO: ugly fix for config values being overwritten by ala defaults
 RUN sed -i '10d' grails-app/conf/application.yml

--- a/docker/collectory/Dockerfile
+++ b/docker/collectory/Dockerfile
@@ -12,7 +12,7 @@ ARG SOURCE=https://github.com/StefanVanDyck/collectory
 ARG COMMIT=29e12de13c5820b672a6b2dd46bba83c5f74eac6
 LABEL ala.version=inbo-${COMMIT}
 
-RUN git clone --branch ${VERSION} --depth 1 ${SOURCE} . && git checkout ${COMMIT}
+RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
 
 COPY ./i18n/ ./grails-app/i18n/
 

--- a/docker/pipelines/Dockerfile
+++ b/docker/pipelines/Dockerfile
@@ -7,7 +7,7 @@ ARG SOURCE=https://github.com/StefanVanDyck/pipelines.git
 LABEL ala.version=inbo-${COMMIT}
 
 WORKDIR /app
-RUN git clone --branch ${VERSION} --depth 1 ${SOURCE} . && git checkout ${COMMIT}
+RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
 
 RUN --mount=type=cache,target=/root/.m2/repository \
     mvn --batch-mode --no-transfer-progress \

--- a/docker/regions/Dockerfile
+++ b/docker/regions/Dockerfile
@@ -11,7 +11,7 @@ ARG SOURCE=https://github.com/StefanVanDyck/regions.git
 LABEL ala.version=inbo-${COMMIT}
 
 WORKDIR /project
-RUN git clone --branch ${VERSION} --depth 1 ${SOURCE} . && git checkout ${COMMIT}
+RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
 
 COPY ./i18n/ ./grails-app/i18n/
 

--- a/docker/spatial-service/Dockerfile
+++ b/docker/spatial-service/Dockerfile
@@ -11,7 +11,7 @@ ARG SOURCE=https://github.com/StefanVanDyck/spatial-service.git
 LABEL ala.version=inbo-${COMMIT}
 
 WORKDIR /project
-RUN git clone --branch ${VERSION} --depth 1 ${SOURCE} . && git checkout ${COMMIT}
+RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
 
 COPY ./i18n/ ./grails-app/i18n/
 


### PR DESCRIPTION
Caused git to complain it could not find the referenced commit as it would only have the last commit