### PR TITLE
#102

### DIFF
--- a/config/biocache-hub/biocache-hub.yml
+++ b/config/biocache-hub/biocache-hub.yml
@@ -195,4 +195,6 @@ useDownloadPlugin: true
 userCharts: false
 userdetails:
   url: ${common.protocol}://${common.domain}/userdetails/
+searchTabs:
+  catalogUpload: false
 

--- a/docker/biocache-hub/Dockerfile
+++ b/docker/biocache-hub/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDPLATFORM=linux/amd64
 FROM --platform=${BUILDPLATFORM} custom-gradle AS builder
 
 ARG VERSION=develop-vbp
-ARG COMMIT=8e554ab7a98e1684c2d9e9e3ef75d7f48594fc58
+ARG COMMIT=c7c28f072dedd23416b41943db9140b04ead93a4
 ARG SOURCE=https://github.com/inbo/biocache-hubs.git
 LABEL ala.version=inbo-${COMMIT}
 


### PR DESCRIPTION
- updated biocache-hubs commit tip
- added config property to hide 'Catalogue number search' tab