### PR TITLE
Do not consider browser language settings

### DIFF
--- a/branding/app/js/i18next-config.js
+++ b/branding/app/js/i18next-config.js
@@ -40,7 +40,7 @@ const i18nOpts = {
 
 const detectorOptions = {
   // order and from where user language should be detected
-  order: ['querystring', 'cookie', 'navigator', 'htmlTag'],
+  order: ['querystring', 'cookie'],
 
   // keys or params to lookup language from
   lookupQuerystring: 'lang',


### PR DESCRIPTION
Always show the portal in Dutch the first time you visit.
Do not consider the users Browser language settings.