### PR TITLE
#271

### DIFF
--- a/config/bie-index/conservation-lists.json
+++ b/config/bie-index/conservation-lists.json
@@ -2,14 +2,14 @@
   "defaultSourceField": "status",
   "lists": [
     {
-      "uid": "drt1738833463033",
+      "uid": "dr136",
       "field": "threatStatus_VRLF_s",
       "sourceField": "threatStatus",
       "term": "threatStatus",
       "label": "VRLF"
     },
     {
-      "uid": "drt1738932783392",
+      "uid": "dr140",
       "field": "threatStatus_NVRLF_s",
       "sourceField": "threatStatus",
       "term": "threatStatus",

--- a/docker/bie-hub/Dockerfile
+++ b/docker/bie-hub/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /project
 # ARG SOURCE=https://github.com/AtlasOfLivingAustralia/ala-bie-hub.git
 
 ARG VERSION=develop
-ARG COMMIT=8c9c239ee067e68be494a38435ccb653283d31ae
+ARG COMMIT=4723fce83f1b2e1227de97e2a42f8b06736cd6b8
 ARG SOURCE=https://github.com/inbo/ala-bie-hub.git
 LABEL ala.version=inbo-${COMMIT}
 


### PR DESCRIPTION
- conservation-lists.json is updated with UAT collectory data resource uids (as it was intended to be before the short switch to species lists' druids_
- bump bie-hub image version