### PR TITLE
#328

### DIFF
--- a/config/bie-index/conservation-lists.json
+++ b/config/bie-index/conservation-lists.json
@@ -1,10 +1,12 @@
 {
   "defaultSourceField": "status",
+  "defaultYearSourceField": "eventDate",
   "lists": [
     {
       "uid": "dr136",
       "field": "threatStatus_VRLF_s",
       "sourceField": "threatStatus",
+      "yearSourceField": "eventDate",
       "term": "threatStatus",
       "label": "VRLF"
     },
@@ -12,6 +14,7 @@
       "uid": "dr140",
       "field": "threatStatus_NVRLF_s",
       "sourceField": "threatStatus",
+      "yearSourceField": "eventDate",
       "term": "threatStatus",
       "label": "NVRLF"
     }

--- a/docker/bie-index/Dockerfile
+++ b/docker/bie-index/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=${BUILDPLATFORM} custom-gradle AS builder
 
 
 ARG VERSION=master
-ARG COMMIT=cdcce55581b5d37173d6536431d92defeb2d7266
+ARG COMMIT=59abb80d6ed97ba4351a1caef30fb06555a9cd86
 ARG SOURCE=https://github.com/inbo/bie-index.git
 LABEL ala.version=inbo-${COMMIT}
 


### PR DESCRIPTION
- add 'yearSourceField' configuration to conservation-lists.json for bie-index; so that only the most recent conservation status is taken during the indexation.
- update bie-index commit tip