### PR TITLE
Switch to amazon corretto as java provider.

### DIFF
--- a/docker/maven/Dockerfile
+++ b/docker/maven/Dockerfile
@@ -1,5 +1,8 @@
 ARG BUILDPLATFORM=linux/amd64
-FROM --platform=${BUILDPLATFORM} maven:3.8-openjdk-8 AS builder
+FROM --platform=${BUILDPLATFORM} maven:3.8-amazoncorretto-8 AS builder
 
 RUN mkdir ~/.m2
 COPY settings.xml /root/.m2/settings.xml
+
+RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    yum -y install git

--- a/docker/spatial-service/Dockerfile
+++ b/docker/spatial-service/Dockerfile
@@ -1,4 +1,3 @@
-ARG BUILDPLATFORM=linux/amd64
 FROM --platform=${BUILDPLATFORM} custom-gradle AS builder
 
 # ARG VERSION=2.1.5
@@ -26,12 +25,16 @@ RUN ls -la /project/build/libs
 
 FROM tomcat-base
 
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
-    gettext-base \
-    gdal-bin libproj-dev proj-data proj-bin # GDAL dependencies
+RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    amazon-linux-extras install epel -y && \
+    yum -y install \
+    gettext \
+    unzip \
+    gdal \
+    proj \
+    proj-data \
+    proj-data-be
+#     gdal-bin libproj-dev proj-data proj-bin # GDAL dependencies
 
 
 # Libraries require linking from <data.dir>/modelling/maxent because the path is required to be a subfolder of the data directory

--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -1,16 +1,18 @@
 ######################################### TOMCAT BASE #########################################
-FROM tomcat:9.0-jdk11-openjdk AS base
+FROM tomcat:9.0-jdk11-corretto AS base
 
 WORKDIR ${CATALINA_HOME}
 
 # Create the user
 ENV UID=1000
 ENV GID=1000
-RUN groupadd --gid ${GID} tomcat \
-    && useradd --uid ${UID} --gid ${GID} -m -d /tomcat tomcat
+
+RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    yum install -y \
+        util-linux
 
 RUN mkdir /data
-RUN chown tomcat:tomcat /data
+RUN chown ${UID}:${GID} /data
 VOLUME /data
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
Should have more LTS support from amazon.
And it fixes an issue I was having running locally. (https://stackoverflow.com/questions/71532170/java-lang-nullpointerexception-cannot-invoke-jdk-internal-platform-cgroupinfo/79244483#79244483)