### PR TITLE
#138

### DIFF
--- a/config/biocache-hub/grouped_facets_default.json
+++ b/config/biocache-hub/grouped_facets_default.json
@@ -186,6 +186,14 @@
       {
         "sort": "index",
         "field": "country"
+      },
+      {
+        "sort": "index",
+        "field": "dynamicProperties_level1Name"
+      },
+      {
+        "sort": "index",
+        "field": "dynamicProperties_level2Name"
       }
     ]
   },

--- a/config/biocache-hub/i18n/override/messages_en.properties
+++ b/config/biocache-hub/i18n/override/messages_en.properties
@@ -1,4 +1,5 @@
-
+facet.dynamicProperties_level1Name=Country region
+facet.dynamicProperties_level2Name=Province
 #. no en data updates
 
 

--- a/config/biocache-hub/i18n/override/messages_nl.properties
+++ b/config/biocache-hub/i18n/override/messages_nl.properties
@@ -117,6 +117,8 @@ verbatimTaxonRank=Verbatim taxonomische rang (dwc:verbatimTaxonRank)
 vernacularName=Volksnaam (dwc:vernacularName)
 waterBody=Waterlichaam (dwc:waterBody)
 year=Jaar (dwc:year)
+facet.dynamicProperties_level1Name=Gewest
+facet.dynamicProperties_level2Name=Provincie
 
 
 

--- a/config/biocache-service/facets.json
+++ b/config/biocache-service/facets.json
@@ -101,6 +101,14 @@
         "field": "country"
       },
       {
+        "sort": "index",
+        "field": "dynamicProperties_level1Name"
+      },
+      {
+        "sort": "index",
+        "field": "dynamicProperties_level2Name"
+      },
+      {
         "sort": "count",
         "field": "sensitive"
       },


### PR DESCRIPTION
- add 2 new facets for Location group: dynamicProperties_level1Name (maps to Gewest) and dynamicProperties_level2Name (maps to Provincie) to be taken up in occurrences search filter