### PR TITLE
#776

### DIFF
--- a/config/biocache-hub/biocache-hub.yml
+++ b/config/biocache-hub/biocache-hub.yml
@@ -50,7 +50,7 @@ dataQualityChecksUrl: ${common.protocol}://${common.domain}/data-quality-checks.
 dataquality:
   enabled: true
   baseUrl: http://data-quality-filter-service.${common.internalDomain}:8080/data-quality-filter-service/
-defaultLocale: nl
+defaultLocale: en
 disableCAS: true
 doi:
   mintDoi: true

--- a/docker/biocache-hub/Dockerfile
+++ b/docker/biocache-hub/Dockerfile
@@ -10,8 +10,6 @@ LABEL ala.version=inbo-${COMMIT}
 WORKDIR /project/biocache-hubs
 RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
 
-COPY resources.xml ./grails-app/conf/spring/resources.xml
-
 RUN --mount=type=cache,target=/gradle-cache,ro \
     gradle build publishToMavenLocal \
     -x test
@@ -23,6 +21,8 @@ LABEL ala.version=inbo-${COMMIT}
 
 WORKDIR /project/ala-hub
 RUN git clone --branch ${VERSION} ${SOURCE} . && git checkout ${COMMIT}
+
+COPY resources.xml ./grails-app/conf/spring/resources.xml
 
 # # TODO: ugly fix for config values being overwritten by ala defaults
 RUN sed -i '10d' grails-app/conf/application.yml


### PR DESCRIPTION
- make sure resources.xml where locale resolver is set to CookieLocaleResolver, is copied to ala-hub project which is the top level project (and not biocache-hubs)
- set default locale to 'en', as in biocache-hubs the default messages.properties is EN; otherwise Grails' message cache is messed up.