### PR TITLE
- add missing config value for alerts service. (we still need to over…

### DIFF
--- a/config/alerts/alerts.yml
+++ b/config/alerts/alerts.yml
@@ -58,6 +58,8 @@ spatial:
   baseURL: "${common.protocol}://${common.domain}/spatial-hub"
 collectory:
   baseURL: "${common.protocol}://${common.domain}/collectory"
+collectoryService:
+  baseURL: "${common.protocol}://${common.domain}/collectory/ws"
 lists:
   baseURL: "${common.protocol}://${common.domain}/species-list"
 speciesPages:


### PR DESCRIPTION
…write the 'base_url' attribute for 'Datasets' query (table 'query') in the dev and prd databases as they are written once and never updated afterwards)