### PR TITLE
fix(test): parse JSON VBP-AUTH cookie to extract userId for annotatio…

### DIFF
--- a/test/cypress/e2e/7-profile/profile.cy.ts
+++ b/test/cypress/e2e/7-profile/profile.cy.ts
@@ -56,12 +56,13 @@ describe("User profile - Authenticated", () => {
 
   it("Show working annotations link", () => {
     cy.getCookie("VBP-AUTH").then((cookie) => {
+      const userId = JSON.parse(decodeURIComponent(cookie!.value)).userId;
       cy.get("#profile-overview")
         .find("#my-profile-my-annotated-records")
         .click();
       cy.url()
         .should("include", "/biocache-hub/occurrences/search/")
-        .should("include", `assertion_user_id:%22${cookie.value}%22`);
+        .should("include", `assertion_user_id:%22${userId}%22`);
       cy.get("h1").contains("Waarnemingsrecords").should("be.visible");
     });
   });


### PR DESCRIPTION
…n URL assertion

The VBP-AUTH cookie format changed from a plain user ID string to a JSON object containing userId and refreshedAt fields. Update the test to parse the JSON value and extract the userId before asserting the assertion_user_id URL parameter.