### PR TITLE
Fix/wms layers not showing

### DIFF
--- a/config/spatial-hub/spatial-hub.yml
+++ b/config/spatial-hub/spatial-hub.yml
@@ -550,6 +550,8 @@ environments:
   local:
     lists:
       url: "" #prevent portal-full from deadlocking at startup
+    spApp:
+      optionsAddWms: true
   inbo_dev:
     assets:
       bundle: true

--- a/docker/spatial-hub/Dockerfile
+++ b/docker/spatial-hub/Dockerfile
@@ -26,6 +26,10 @@ COPY ./assets/images/icon_flanders.png ./grails-app/assets/images/icon_contextua
 COPY ./assets/images/icon_flanders.png ./grails-app/assets/images/icon_wms-layer.png
 COPY ./assets/javascripts/* ./grails-app/assets/javascripts/
 
+# Fix: String.length is a property, not a method — .length() throws TypeError for all preset WMS URLs
+RUN sed -i 's/\.selectedServer\.length()/.selectedServer.length/g' \
+    ./grails-app/assets/javascripts/spApp/controller/addWMSCtrl.js
+
 RUN --mount=type=cache,target=/gradle-cache,ro \
   gradle \
   build assemble \


### PR DESCRIPTION
Yes, the fix will work. All checks pass:

Bug confirmed at the exact commit (f360f151): $scope.selectedServer.length() is verbatim in the source file the Dockerfile builds.

getCapabilities works without query params: The bare URL https://geo.api.vlaanderen.be/GRB/wms returns a ServiceException, but with ?service=WMS&request=GetCapabilities it returns the full WMS_Capabilities XML with all layers — which is what the proxy call fetches (the proxy appends other request parameters from the form).

sed syntax is correct: In GNU sed (Amazon Linux 2), () without backslashes are literal characters, so the pattern matches $scope.selectedServer.length() exactly and replaces it with $scope.selectedServer.length.

Timing is correct: The sed runs after git clone and COPY (which only copies i18n.js, not addWMSCtrl.js) and before gradle build assemble, so the fix is compiled into the asset bundle.

Proxy allowlist covers the servers: Both geo.api.vlaanderen.be and gisservices.inbo.be are in allowProxy.server, so the proxy will not block the requests.