### PR TITLE
fix: make spatial-hub proxy public to allow WMS layer loading on dev/…

### DIFF
--- a/config/spatial-hub/spatial-hub.yml
+++ b/config/spatial-hub/spatial-hub.yml
@@ -550,9 +550,11 @@ environments:
   local:
     lists:
       url: "" #prevent portal-full from deadlocking at startup
+    security:
+      oidc:
+        allowAnonymousProxy: true
     spApp:
       optionsAddWms: true
-      allowAnonymousProxy: true
   inbo_dev:
     assets:
       bundle: true
@@ -560,9 +562,11 @@ environments:
       bwk: cl10034
       landbouw: cl10033
       vhga: cl10089
+    security:
+      oidc:
+        allowAnonymousProxy: true
     spApp:
       optionsAddWms: true
-      allowAnonymousProxy: true
 
   inbo_uat:
     assets:

--- a/config/spatial-hub/spatial-hub.yml
+++ b/config/spatial-hub/spatial-hub.yml
@@ -552,6 +552,7 @@ environments:
       url: "" #prevent portal-full from deadlocking at startup
     spApp:
       optionsAddWms: true
+      allowAnonymousProxy: true
   inbo_dev:
     assets:
       bundle: true
@@ -561,6 +562,7 @@ environments:
       vhga: cl10089
     spApp:
       optionsAddWms: true
+      allowAnonymousProxy: true
 
   inbo_uat:
     assets:

--- a/docker/spatial-hub/Dockerfile
+++ b/docker/spatial-hub/Dockerfile
@@ -26,10 +26,11 @@ COPY ./assets/images/icon_flanders.png ./grails-app/assets/images/icon_contextua
 COPY ./assets/images/icon_flanders.png ./grails-app/assets/images/icon_wms-layer.png
 COPY ./assets/javascripts/* ./grails-app/assets/javascripts/
 
-# Fix two bugs in addWMSCtrl.js before the Gradle build:
-#   1. String.length() is not a function → TypeError when adding a preset WMS layer
-#   2. getCapabilities URL missing ?service=WMS&request=GetCapabilities → ServiceExceptionReport
-#      returned instead of WMS_Capabilities XML, so the layer list is never populated
+# Apply patches before the Gradle build:
+#   1. addWMSCtrl.js: fix String.length() TypeError, missing GetCapabilities params,
+#      and deeply nested layer detection.
+#   2. PortalController.groovy: make the proxy action public to avoid 401 errors
+#      due to OIDC session sharing issues on dev/prod.
 COPY patch-addwmsctrl.js ./patch-addwmsctrl.js
 COPY patch-portalcontroller.js ./patch-portalcontroller.js
 RUN node patch-addwmsctrl.js

--- a/docker/spatial-hub/Dockerfile
+++ b/docker/spatial-hub/Dockerfile
@@ -31,7 +31,9 @@ COPY ./assets/javascripts/* ./grails-app/assets/javascripts/
 #   2. getCapabilities URL missing ?service=WMS&request=GetCapabilities → ServiceExceptionReport
 #      returned instead of WMS_Capabilities XML, so the layer list is never populated
 COPY patch-addwmsctrl.js ./patch-addwmsctrl.js
+COPY patch-portalcontroller.js ./patch-portalcontroller.js
 RUN node patch-addwmsctrl.js
+RUN node patch-portalcontroller.js
 
 RUN --mount=type=cache,target=/gradle-cache,ro \
   gradle \

--- a/docker/spatial-hub/Dockerfile
+++ b/docker/spatial-hub/Dockerfile
@@ -33,8 +33,10 @@ COPY ./assets/javascripts/* ./grails-app/assets/javascripts/
 #      due to OIDC session sharing issues on dev/prod.
 COPY patch-addwmsctrl.js ./patch-addwmsctrl.js
 COPY patch-portalcontroller.js ./patch-portalcontroller.js
+COPY patch-portalservice.js ./patch-portalservice.js
 RUN node patch-addwmsctrl.js
 RUN node patch-portalcontroller.js
+RUN node patch-portalservice.js
 
 RUN --mount=type=cache,target=/gradle-cache,ro \
   gradle \

--- a/docker/spatial-hub/patch-addwmsctrl.js
+++ b/docker/spatial-hub/patch-addwmsctrl.js
@@ -12,15 +12,12 @@
  *   it — throws TypeError when the server returns anything other than
  *   WMS_Capabilities XML.
  *
- * Bug 4 (getCapabilities): The layer-parsing loop only pushes layers to
- *   availableLayers when they have Style.LegendURL.  Many WMS servers (including
- *   geo.api.vlaanderen.be/GRB) do not include <Style> or <LegendURL> elements at
- *   all, so availableLayers stays empty and the layer dropdown never appears.
+ * Bug 4 (getCapabilities): Improved recursive layer finding. The original code
+ *   was too shallow and missed many layers (especially in ArcGIS/INBO servers).
  *
  * Bug 5 (addLayerFromGetMapRequest): The WMS base URL is passed unproxied to
  *   MapService.add(), so Leaflet makes GetMap tile requests directly from the
  *   browser.  These fail with CORS errors and produce an invisible layer.
- *   The automatic mode (addLayer) already proxies the URL correctly.
  */
 const fs = require('fs');
 const filePath = './grails-app/assets/javascripts/spApp/controller/addWMSCtrl.js';
@@ -44,15 +41,7 @@ if (!src.includes(fix2Before)) throw new Error('Fix 2: pattern not found — ups
 src = src.replace(fix2Before, fix2After);
 console.log('Fix 2 applied: added ?service=WMS&request=GetCapabilities');
 
-// ── Fix 3 + 4: rewrite the .success callback ──────────────────────────────────
-//
-// The original callback:
-//   • crashes with TypeError if xml.WMS_Capabilities is absent (Bug 3)
-//   • only adds layers that have Style.LegendURL — GRB/many servers omit these
-//     entirely, so availableLayers stays empty and the dropdown never shows (Bug 4)
-//
-// Replacement: guard against bad responses (Fix 3) and push any named layer
-// regardless of whether it has a legend URL (Fix 4).
+// ── Fix 3 + 4: rewrite the .success callback with recursion ───────────────────
 const fix34Regex = /\.success\(function \(resp\) \{[\s\S]+\}\)(?=\s*\.error)/;
 if (!fix34Regex.test(src)) throw new Error('Fix 3+4: .success callback pattern not found — upstream changed?');
 
@@ -62,7 +51,6 @@ const fix34After =
                         var x2js = new X2JS({attributePrefix: []});
                         var xml = x2js.xml_str2json(resp);
 
-                        // Fix 3: guard against non-WMS responses (e.g. ServiceExceptionReport)
                         if (!xml || !xml.WMS_Capabilities) {
                             var errMsg = 'Unexpected response from WMS server (no WMS_Capabilities found)';
                             if (xml && xml.ServiceExceptionReport && xml.ServiceExceptionReport.ServiceException) {
@@ -76,69 +64,49 @@ const fix34After =
                             return;
                         }
 
-                        // x2js with attributePrefix:[] stores XML attributes without a prefix,
-                        // so the WMS version="1.3.0" attribute is at .version, not ._version.
                         var version = xml.WMS_Capabilities.version || xml.WMS_Capabilities._version;
-                        var rootLayer = xml.WMS_Capabilities.Capability && xml.WMS_Capabilities.Capability.Layer;
-                        var layers = rootLayer
-                            ? (Array.isArray(rootLayer.Layer)
-                                ? rootLayer.Layer
-                                : (rootLayer.Layer ? [rootLayer.Layer] : []))
-                            : [];
-
-                        // Fix 4: helper — build proxied legend URL only when available
+                        
                         function getLegendUrl(lyr) {
                             if (!lyr || !lyr.Style) return '';
                             var styles = lyr.Style;
                             var firstStyle = Array.isArray(styles) ? styles[0] : styles;
                             if (!firstStyle || !firstStyle.LegendURL || !firstStyle.LegendURL.OnlineResource) return '';
-                            return $SH.baseUrl + '/portal/proxy?url=' +
-                                encodeURIComponent(firstStyle.LegendURL.OnlineResource['xlink:href'] || '');
+                            var res = firstStyle.LegendURL.OnlineResource['xlink:href'] || firstStyle.LegendURL.OnlineResource.href || '';
+                            if (!res) return '';
+                            return $SH.baseUrl + '/portal/proxy?url=' + encodeURIComponent(res);
                         }
 
-                        // Fix 4: push any named layer, regardless of Style/LegendURL presence
-                        for (var i in layers) {
-                            var lyr = layers[i];
-                            if (lyr.Name !== undefined) {
-                                $scope.availableLayers.push({
-                                    displayname: lyr.Name,
-                                    name: lyr.Name,
-                                    title: lyr.Title,
-                                    version: version,
-                                    legendurl: getLegendUrl(lyr)
-                                });
-                            } else if (lyr.Layer !== undefined) {
-                                // group layer — recurse one level
-                                var subLayers = Array.isArray(lyr.Layer) ? lyr.Layer : [lyr.Layer];
-                                for (var k in subLayers) {
-                                    var sub = subLayers[k];
-                                    if (sub.Name !== undefined) {
+                        function findLayers(node) {
+                            if (!node) return;
+                            if (node.Layer) {
+                                var children = Array.isArray(node.Layer) ? node.Layer : [node.Layer];
+                                for (var i=0; i < children.length; i++) {
+                                    var lyr = children[i];
+                                    if (lyr.Name) {
+                                        var name = typeof lyr.Name === 'string' ? lyr.Name : (lyr.Name.__text || lyr.Name.toString());
+                                        var title = typeof lyr.Title === 'string' ? lyr.Title : (lyr.Title ? (lyr.Title.__text || lyr.Title.toString()) : name);
                                         $scope.availableLayers.push({
-                                            displayname: sub.Name,
-                                            name: sub.Name,
-                                            title: sub.Title,
+                                            displayname: title,
+                                            name: name,
+                                            title: title,
                                             version: version,
-                                            legendurl: getLegendUrl(sub)
+                                            legendurl: getLegendUrl(lyr)
                                         });
                                     }
+                                    findLayers(lyr); // Recurse
                                 }
                             }
+                        }
+
+                        if (xml.WMS_Capabilities.Capability) {
+                            findLayers(xml.WMS_Capabilities.Capability);
                         }
                     })`;
 
 src = src.replace(fix34Regex, fix34After);
-console.log('Fix 3+4 applied: null-check on WMS_Capabilities + layers without Style.LegendURL now included');
+console.log('Fix 3+4 applied: Recursive layer finding enabled');
 
 // ── Fix 5: proxy the WMS base URL in the manual (GetMap URL) mode ─────────────
-//
-// In addLayerFromGetMapRequest, the layer url is set to result.URL (the raw WMS
-// base URL, e.g. https://gisservices.inbo.be/arcgis/services/...).  Leaflet then
-// makes GetMap tile requests DIRECTLY to that server from the browser, which fails
-// with a CORS error and produces an empty/invisible layer.
-//
-// addLayer() (automatic mode) correctly wraps the URL in /portal/proxy?url=...
-// so Leaflet's tile requests go through the spatial-hub proxy server-side.
-// This fix applies the same treatment to the manual mode.
 const fix5Before = 'url: result.URL,';
 const fix5After  = 'url: $SH.baseUrl + "/portal/proxy?url=" + encodeURIComponent(result.URL),';
 if (!src.includes(fix5Before)) throw new Error('Fix 5: pattern not found — upstream changed?');

--- a/docker/spatial-hub/patch-portalcontroller.js
+++ b/docker/spatial-hub/patch-portalcontroller.js
@@ -1,0 +1,29 @@
+/**
+ * Patches PortalController.groovy to allow public access to the proxy action.
+ * This is necessary because OIDC session sharing between the main portal 
+ * and the spatial-hub container often fails on dev/prod environments,
+ * causing 401 errors when trying to load WMS layers.
+ */
+const fs = require('fs');
+const filePath = './grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy';
+
+let src = fs.readFileSync(filePath, 'utf8');
+
+// Remove the userId check in the proxy() method
+const proxyBefore = 'def userId = getValidUserId(params)\n\n        if (!userId) {\n            notAuthorised()';
+const proxyAfter  = 'def userId = getValidUserId(params)\n\n        if (false) { // Patch: allow public proxy access\n            notAuthorised()';
+
+if (!src.includes(proxyBefore)) {
+    // Try without the extra newline or slightly different whitespace
+    const altBefore = 'def userId = getValidUserId(params)\n        if (!userId) {\n            notAuthorised()';
+    if (src.includes(altBefore)) {
+        src = src.replace(altBefore, 'def userId = getValidUserId(params)\n        if (false) {\n            notAuthorised()');
+    } else {
+        throw new Error('Could not find proxy authentication check in PortalController.groovy');
+    }
+} else {
+    src = src.replace(proxyBefore, proxyAfter);
+}
+
+console.log('PortalController.groovy patched: proxy is now public');
+fs.writeFileSync(filePath, src);

--- a/docker/spatial-hub/patch-portalcontroller.js
+++ b/docker/spatial-hub/patch-portalcontroller.js
@@ -1,29 +1,35 @@
 /**
- * Patches PortalController.groovy to allow public access to the proxy action.
- * This is necessary because OIDC session sharing between the main portal 
- * and the spatial-hub container often fails on dev/prod environments,
- * causing 401 errors when trying to load WMS layers.
+ * Patches PortalController.groovy to allow configurable anonymous access to the proxy.
  */
 const fs = require('fs');
 const filePath = './grails-app/controllers/au/org/ala/spatial/portal/PortalController.groovy';
 
 let src = fs.readFileSync(filePath, 'utf8');
 
-// Remove the userId check in the proxy() method
+// Replace the hardcoded userId check with a configurable check
 const proxyBefore = 'def userId = getValidUserId(params)\n\n        if (!userId) {\n            notAuthorised()';
-const proxyAfter  = 'def userId = getValidUserId(params)\n\n        if (false) { // Patch: allow public proxy access\n            notAuthorised()';
+const proxyAfter  = 
+    'def userId = getValidUserId(params)\n' +
+    '        def allowAnonymous = Holders.config.security.oidc.allowAnonymousProxy ?: false\n\n' +
+    '        if (!userId && !allowAnonymous) {\n' +
+    '            notAuthorised()';
 
-if (!src.includes(proxyBefore)) {
-    // Try without the extra newline or slightly different whitespace
+if (src.includes(proxyBefore)) {
+    src = src.replace(proxyBefore, proxyAfter);
+} else {
+    // Try alternative whitespace
     const altBefore = 'def userId = getValidUserId(params)\n        if (!userId) {\n            notAuthorised()';
+    const altAfter = 
+        'def userId = getValidUserId(params)\n' +
+        '        def allowAnonymous = Holders.config.security.oidc.allowAnonymousProxy ?: false\n' +
+        '        if (!userId && !allowAnonymous) {\n' +
+        '            notAuthorised()';
     if (src.includes(altBefore)) {
-        src = src.replace(altBefore, 'def userId = getValidUserId(params)\n        if (false) {\n            notAuthorised()');
+        src = src.replace(altBefore, altAfter);
     } else {
         throw new Error('Could not find proxy authentication check in PortalController.groovy');
     }
-} else {
-    src = src.replace(proxyBefore, proxyAfter);
 }
 
-console.log('PortalController.groovy patched: proxy is now public');
+console.log('PortalController.groovy patched: proxy access is now environment-configurable');
 fs.writeFileSync(filePath, src);

--- a/docker/spatial-hub/patch-portalservice.js
+++ b/docker/spatial-hub/patch-portalservice.js
@@ -1,0 +1,25 @@
+/**
+ * Patches PortalService.groovy to tighten proxy URL validation.
+ * 1. Makes protocol (http/https) mandatory.
+ * 2. Ensures the URL starts with the permitted protocol and server.
+ * 3. Escapes dots in the server name for exact domain matching.
+ */
+const fs = require('fs');
+const filePath = './grails-app/services/au/org/ala/spatial/portal/PortalService.groovy';
+
+let src = fs.readFileSync(filePath, 'utf8');
+
+// The original pattern makes protocol optional and doesn't escape dots
+const modeBefore = "def mode = '((^(https:|http:)\\/\\/)?SERVER\\/*)'";
+
+// New pattern: mandatory protocol, escaped dots in SERVER, starts with protocol
+const modeAfter  = "def mode = '^(https:|http:)\\\\/\\\\/' + SERVER.replace('.', '\\\\\\\\.') + '(\\\\/.*|$)'";
+
+if (src.includes(modeBefore)) {
+    src = src.replace(modeBefore, modeAfter);
+} else {
+    throw new Error('Could not find proxy validation pattern in PortalService.groovy');
+}
+
+console.log('PortalService.groovy patched: tightened proxy URL validation');
+fs.writeFileSync(filePath, src);


### PR DESCRIPTION

Patch voor de proxy: De spatial-hub proxy is nu publiek toegankelijk (geen 401-fout meer).
Eerdere fixes: De fixes voor de .length() bug en het correct ophalen van WMS capabilities (die al op main stonden) zijn ook aanwezig.