### PR TITLE
inbo/vlaams-biodiversiteitsportaal#1107

### DIFF
--- a/config/spatial-service/spatial-service.yml
+++ b/config/spatial-service/spatial-service.yml
@@ -80,7 +80,7 @@ batch_sampling_passwords: ""
 ala.baseURL: "${common.protocol}://${common.domain}"
 bie.baseURL: "${common.protocol}://bie.${common.domain}"
 bie.searchPath: "/search"
-biocacheServiceUrl: "${common.protocol}://${common.domain}/biocache-service"
+biocacheServiceUrl: "http://biocache-service.${common.internalDomain}:8080/biocache-service"
 biocacheUrl: "${common.protocol}://${common.domain}/biocache-hub"
 
 namematching.url: http://namematching-service.${common.internalDomain}:9179


### PR DESCRIPTION
- the biocache-service URL must be the internal discovery URL, not external