### PR TITLE
fix: stabilize charts and hide not supplied values

### DIFF
--- a/config/bie-hub/charts.json
+++ b/config/bie-hub/charts.json
@@ -4,34 +4,50 @@
       "title": "By month",
       "chartType": "bar",
       "emptyValueMsg": "Month not specified",
-      "hideEmptyValues": true
+      "hideEmptyValues": true,
+      "includeOther": "false"
     },
     "year": {
       "title": "Since 1990",
       "chartType": "bar",
       "emptyValueMsg": "Year not specified",
       "hideEmptyValues": true,
+      "includeOther": "false",
       "filter": "fq=year:%5B1990 TO *%5D"
     },
     "decade": {
       "title": "By decade",
       "chartType": "bar",
       "emptyValueMsg": "Year not specified",
-      "hideEmptyValues": true
+      "hideEmptyValues": true,
+      "includeOther": "false"
     },
     "data_provider_uid": {
       "title": "By data partner",
       "chartType": "horizontal-bar",
       "emptyValueMsg": "Partner not specified",
-      "hideEmptyValues": true
+      "hideEmptyValues": true,
+      "includeOther": "false",
+      "filter": "fsort=count",
+      "growToFit": true
     },
     "collection_uid": {
       "title": "By collection",
-      "chartType": "horizontal-bar"
+      "chartType": "horizontal-bar",
+      "emptyValueMsg": "Collection not specified",
+      "hideEmptyValues": true,
+      "includeOther": "false",
+      "filter": "fsort=count",
+      "growToFit": true
     },
     "data_resource_uid": {
       "title": "By dataset",
-      "chartType": "horizontal-bar"
+      "chartType": "horizontal-bar",
+      "emptyValueMsg": "Dataset not specified",
+      "hideEmptyValues": true,
+      "includeOther": "false",
+      "filter": "fsort=count",
+      "growToFit": true
     }
   }
 }

--- a/config/biocache-hub/charts.json
+++ b/config/biocache-hub/charts.json
@@ -14,21 +14,24 @@
       "emptyValueMsg": "Soortgroep niet gespecificeerd",
       "hideEmptyValues": true,
       "includeOther": "false",
-      "filter": "fsort=count"
+      "filter": "fsort=count",
+      "growToFit": true
     },
     "month": {
       "title": "Per maand",
       "chartType": "bar",
       "emptyValueMsg": "Maand niet gespecificeerd",
       "hideEmptyValues": true,
-      "includeOther": "false"
+      "includeOther": "false",
+      "filter": "fq=month:%2A&fq=-month:%22not%20supplied%22&fq=-month:%22Not%20supplied%22"
     },
     "year": {
       "title": "Per jaar",
       "chartType": "bar",
       "emptyValueMsg": "Jaar niet gespecificeerd",
       "hideEmptyValues": true,
-      "includeOther": "false"
+      "includeOther": "false",
+      "filter": "fq=year:%2A&fq=-year:%22not%20supplied%22&fq=-year:%22Not%20supplied%22"
     },
     "genus": {
       "title": "Per geslacht",


### PR DESCRIPTION
- remove invalid *_defined chart facets causing 400 errors

- exclude not supplied from genus/family/verification/month/year

- enable growToFit on crowded horizontal charts

- align BIE chart config with consistent empty/other handling