### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,12 +26,12 @@ jobs:
         run: |
           apt-get update && apt-get install -y git-lfs
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           lfs: true
 
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6
         env:
           CYPRESS_VBP_USERNAME: ${{ secrets.CYPRESS_VBP_USERNAME }}
           CYPRESS_VBP_PASSWORD: ${{ secrets.CYPRESS_VBP_PASSWORD }}
@@ -39,7 +39,7 @@ jobs:
         with:
           working-directory: ./test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         id: upload-screen-captures
         if: failure()
         with:
@@ -169,13 +169,13 @@ jobs:
       - name: Install Copilot CLI
         run: npm install -g @github/copilot
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           lfs: true
           fetch-depth: 0
 
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: upload-screen-captures
           path: ./test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   get-versions:
     runs-on: [self-hosted]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -92,9 +92,9 @@ jobs:
     needs: get-versions
     if: needs.get-versions.outputs.branding_version != ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 23
           cache: "npm"
@@ -114,14 +114,14 @@ jobs:
           tar -cvzf branding-${{ needs.get-versions.outputs.branding_version }}.tar.gz -C "$(pwd)/dist" ./
 
       - name: Archive failed test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: branding-tests
           path: ./test-output.json
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           commit: ${{ github.sha }}
           tag: branding-v${{ needs.get-versions.outputs.branding_version }}
@@ -135,7 +135,7 @@ jobs:
       contents: write
     steps:
       - name: Create tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const versions = ${{ fromJSON(needs.get-versions.outputs.config_versions) }};
@@ -162,12 +162,12 @@ jobs:
       matrix:
         docker: ${{ fromJSON(needs.get-versions.outputs.docker_build_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to AWS
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_SHARED_INFRA_ROLE_ARN }}
@@ -184,10 +184,10 @@ jobs:
             | docker login --username AWS --password-stdin ${{ secrets.ECR_MIRROR_REPO }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           cache-binary: false
           platforms: linux/amd64,linux/arm64
@@ -199,7 +199,7 @@ jobs:
       #            image=moby/buildkit:buildx-stable-1
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache
         with:
           path: |
@@ -213,7 +213,7 @@ jobs:
             cache-docker-${{ matrix.docker.component }}
 
       - name: inject cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        uses: reproducible-containers/buildkit-cache-dance@5de31fc1534ed8789e63d41ea933c5df9944a261 # v3.1.0
         with:
           cache-map: |
             {
@@ -290,7 +290,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout terraform repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "inbo/inbo-aws-biodiversiteitsportaal-terraform"
           token: ${{ secrets.GIT_PAT_TOKEN }}
@@ -320,7 +320,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: steps.update-versions.outputs.changes == 'true'
         with:
           github-token: ${{ secrets.GIT_PAT_TOKEN }}

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -11,12 +11,12 @@ jobs:
   update-translations:
     runs-on: [ self-hosted ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -64,7 +64,7 @@ jobs:
           fi      
 
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: steps.update-translations.outputs.changes == 'true'
         with:
           github-token: ${{ secrets.GIT_PAT_TOKEN }}


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._