### PR TITLE
inbo/vlaams-biodiversiteitsportaal#1205

### DIFF
--- a/config/biocache-hub/grouped_facets_default.json
+++ b/config/biocache-hub/grouped_facets_default.json
@@ -127,6 +127,10 @@
       {
         "sort": "count",
         "field": "behavior"
+      },
+      {
+        "sort": "count",
+        "field": "dynamicProperties_iucnRedListCategory"
       }
     ]
   },

--- a/config/biocache-hub/i18n/override/messages_en.properties
+++ b/config/biocache-hub/i18n/override/messages_en.properties
@@ -1,4 +1,5 @@
 facet.dynamicProperties_level2Name=Province
+facet.dynamicProperties_iucnRedListCategory=IUCN Status
 facet.species_list_uid=Species lists
 facet.verbatimCoordinateSystem=Verbatim Coordinate System
 facet.sampling_protocol=Sampling protocol

--- a/config/biocache-hub/i18n/override/messages_nl.properties
+++ b/config/biocache-hub/i18n/override/messages_nl.properties
@@ -134,6 +134,7 @@ vernacularName=Nederlandse naam (dwc:vernacularName)
 waterBody=Waterlichaam
 year=Jaar (dwc:year)
 facet.dynamicProperties_level2Name=Provincie
+facet.dynamicProperties_iucnRedListCategory=IUCN Status
 facet.species_group=Soortengroep
 facet.verbatimCoordinateSystem=Verbatim coördinaten systeem
 facet.sampling_protocol=Bemonsteringsprotocol

--- a/config/biocache-service/facets.json
+++ b/config/biocache-service/facets.json
@@ -178,6 +178,10 @@
         "field": "raw_state_conservation"
       },
       {
+        "sort": "count",
+        "field": "dynamicProperties_iucnRedListCategory"
+      },
+      {
         "sort": "index",
         "field": "event_id"
       }


### PR DESCRIPTION
- an attempt to use already existing 'dynamicProperties_iucnRedListCategory' biocache solr field as a IUCN status facet.