### PR TITLE
inbo/vlaams-biodiversiteitsportaal#1174

### DIFF
--- a/config/bie-hub/envs/prod/plugin-tabs.json
+++ b/config/bie-hub/envs/prod/plugin-tabs.json
@@ -12,7 +12,7 @@
     },
     {
       "tab": "ecopedia",
-      "speciesList": "dr462",
+      "speciesList": "dr1006",
       "contentKey": "contentFilePath"
     }
   ]


### PR DESCRIPTION
- bie-hub config change: Ecopedia species list has been reuploaded with the new attribute (nodeType), hence list ID update